### PR TITLE
Bugfix for Django >= 1.7 migrations

### DIFF
--- a/gdstorage/storage.py
+++ b/gdstorage/storage.py
@@ -16,11 +16,12 @@ import requests
 
 DJANGO_VERSION = django.VERSION[:2]
 
+
 class GoogleDriveStorage(Storage):
     """
     Storage class for Django that interacts with Google Drive as persistent storage.
-    This class uses a system account for Google API that create an application drive 
-    (the drive is not owned by any Google User, but it is owned by the application declared on 
+    This class uses a system account for Google API that create an application drive
+    (the drive is not owned by any Google User, but it is owned by the application declared on
     Google API console).
     """
 
@@ -53,19 +54,6 @@ class GoogleDriveStorage(Storage):
 
         self._drive_service = build('drive', 'v2', http=http)
 
-    if DJANGO_VERSION >= (1, 7):
-        def deconstruct(self):
-            """
-                Handle field serialization to support migration
-
-            """
-            name, path, args, kwargs = super(GoogleDriveStorage, self).deconstruct()
-            if self._service_email is not None:
-                kwargs["service_email"] = self._service_email
-            if self._key is not None:
-                kwargs["private_key"] = self._key
-            if self._user_email is not None:
-                kwargs["user_email"] = self._user_email
 
     def _split_path(self, p):
         """
@@ -287,3 +275,23 @@ class GoogleDriveStorage(Storage):
             return None
         else:
             return parse(file_data["modifiedDate"])
+
+
+if DJANGO_VERSION >= (1, 7):
+    from django.utils.deconstruct import deconstructible
+
+    @deconstructible
+    class GoogleDriveStorage(GoogleDriveStorage):
+        def deconstruct(self):
+            """
+                Handle field serialization to support migration
+
+            """
+            name, path, args, kwargs = \
+                super(GoogleDriveStorage, self).deconstruct()
+            if self._service_email is not None:
+                kwargs["service_email"] = self._service_email
+            if self._key is not None:
+                kwargs["private_key"] = self._key
+            if self._user_email is not None:
+                kwargs["user_email"] = self._user_email


### PR DESCRIPTION
When attempting to run a DB migration in Django 1.8, I got an AttributeError because GoogleDriveStorage (inheriting from `django.core.files.storage.Storage`) does not have a `deconstruct` method. See trace:
```
web_1 | Traceback (most recent call last):
web_1 |   File "manage.py", line 10, in <module>
web_1 |     execute_from_command_line(sys.argv)
web_1 |   File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 338, in execute_from_command_line
web_1 |     utility.execute()
web_1 |   File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 330, in execute
web_1 |     self.fetch_command(subcommand).run_from_argv(self.argv)
web_1 |   File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 390, in run_from_argv
web_1 |     self.execute(*args, **cmd_options)
web_1 |   File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 441, in execute
web_1 |     output = self.handle(*args, **options)
web_1 |   File "/usr/local/lib/python2.7/site-packages/django/core/management/commands/migrate.py", line 207, in handle
web_1 |     changes = autodetector.changes(graph=executor.loader.graph)
web_1 |   File "/usr/local/lib/python2.7/site-packages/django/db/migrations/autodetector.py", line 43, in changes
web_1 |     changes = self._detect_changes(convert_apps, graph)
web_1 |   File "/usr/local/lib/python2.7/site-packages/django/db/migrations/autodetector.py", line 183, in _detect_changes
web_1 |     self.generate_renamed_fields()
web_1 |   File "/usr/local/lib/python2.7/site-packages/django/db/migrations/autodetector.py", line 735, in generate_renamed_fields
web_1 |     field_dec = self.deep_deconstruct(field)
web_1 |   File "/usr/local/lib/python2.7/site-packages/django/db/migrations/autodetector.py", line 67, in deep_deconstruct
web_1 |     for key, value in kwargs.items()
web_1 |   File "/usr/local/lib/python2.7/site-packages/django/db/migrations/autodetector.py", line 67, in <dictcomp>
web_1 |     for key, value in kwargs.items()
web_1 |   File "/usr/local/lib/python2.7/site-packages/django/db/migrations/autodetector.py", line 57, in deep_deconstruct
web_1 |     deconstructed = obj.deconstruct()
web_1 |   File "/usr/local/lib/python2.7/site-packages/gdstorage/storage.py", line 62, in deconstruct
web_1 |     name, path, args, kwargs = super(GoogleDriveStorage, self).deconstruct()
web_1 | AttributeError: 'super' object has no attribute 'deconstruct'
```
Decorating the GoogleDriveStorage class with `@deconstructible` for Django versions 1.7 and above solves this problem. (see FileSystemStorage https://github.com/django/django/blob/master/django/core/files/storage.py#L174-L175)

I also moved the `deconstruct` override to this block to keep it organized.

I have not tested this in versions < 1.7.

Otherwise, seems to work as intended. Thank you for this project!