### PR TITLE
Fix file load using open()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ certificate/Django Google Drive Storage-44bb261c98ae.p12
 build
 docs/test
 docs/out
+.ropeproject

--- a/gdstorage/storage.py
+++ b/gdstorage/storage.py
@@ -152,8 +152,10 @@ class GoogleDriveStorage(Storage):
 
     def _open(self, name, mode='rb'):
         file_data = self._check_file_exists(name)
-        r = requests.get(file_data['alternateLink'])
-        return File(BytesIO(r.content), name)
+        response, content = self._drive_service._http.request(
+            file_data['downloadUrl'])
+
+        return File(BytesIO(content), name)
 
     def _save(self, name, content):
         folder_path = os.path.sep.join(self._split_path(name)[:-1])


### PR DESCRIPTION
Hi @torre76 - I have another quick fix to offer:

I updated the `_open` method so the original uploaded file may be downloaded directly.
Using the `alternateLink` here loaded the Google Drive HTML preview page as opposed to the actual source file.

Many thanks! M