### PR TITLE
Specifying what kind of permission storage sets to a newly uploaded file

### DIFF
--- a/gdstorage/storage.py
+++ b/gdstorage/storage.py
@@ -30,7 +30,8 @@ class GoogleDriveStorage(Storage):
     _UNKNOWN_MIMETYPE_ = "application/octet-stream"
     _GOOGLE_DRIVE_FOLDER_MIMETYPE_ = "application/vnd.google-apps.folder"
 
-    def __init__(self, service_email=None, json_keyfile_path=None):
+    def __init__(self, service_email=None, json_keyfile_path=None,
+                 permission={'type': 'anyone', 'role': 'reader'}):
         """
         Handles credentials and builds the google service.
 
@@ -174,12 +175,8 @@ class GoogleDriveStorage(Storage):
             body=body,
             media_body=media_body).execute()
 
-        # Setting up public permission
-        public_permission = {
-            'type': 'anyone',
-            'role': 'reader'
-        }
-        self._drive_service.permissions().insert(fileId=file_data["id"], body=public_permission).execute()
+        # Setting up permission
+        self._drive_service.permissions().insert(fileId=file_data["id"], body=self.permission).execute()
 
         return file_data[u'originalFilename']
 


### PR DESCRIPTION
It's understandable that the most popular use case of the storage is uploading static files which are always publicly readable and don't have to be accessible to any user from a web UI.

However, I've just ran into another use case that requires files to be private and accessing from a Google Drive web UI. With current setup it is possible to achieve that using something like this:

```python
from gdstorage.storage import GoogleDriveStorage
from django.core.files.base import File
storage = GoogleDriveStorage()

name = storage.save('filename.txt', File(f))
file_data = storage._check_file_exists(name)
new_permission = {
        'type': 'user',
        'role': 'writer',
        'value':  'foo@bar.bar',
}
storage._drive_service.permissions().insert(fileId=file_data["id"], body=new_permission).execute()
```
but this is a bit ugly, and could be made more concise if the permission could be set prior to saving, like so:

```python
from gdstorage.storage import GoogleDriveStorage
from django.core.files.base import File
storage = GoogleDriveStorage()

storage.permission = {
        'type': 'user',
        'role': 'writer',
        'value':  'foo@bar.bar',
}
name = storage.save('filename.txt', File(f))
```
or this:

```python
from gdstorage.storage import GoogleDriveStorage
from django.core.files.base import File
storage = GoogleDriveStorage(permission={
        'type': 'user',
        'role': 'writer',
        'value':  'foo@bar.bar'
})

name = storage.save('filename.txt', File(f))
```