### PR TITLE
Setting permissions in a separate call sometimes causes 500

### DIFF
--- a/gdstorage/storage.py
+++ b/gdstorage/storage.py
@@ -314,7 +314,8 @@ class GoogleDriveStorage(Storage):
         media_body = MediaIoBaseUpload(fd, mime_type, resumable=True)
         body = {
             'title': name,
-            'mimeType': mime_type
+            'mimeType': mime_type,
+            'permissions': [p.raw for p in self._permissions]
         }
         # Set the parent folder.
         if parent_id:
@@ -322,10 +323,6 @@ class GoogleDriveStorage(Storage):
         file_data = self._drive_service.files().insert(
             body=body,
             media_body=media_body).execute()
-
-        # Setting up permissions
-        for p in self._permissions:
-            self._drive_service.permissions().insert(fileId=file_data["id"], body=p.raw).execute()
 
         return file_data[u'originalFilename']
 


### PR DESCRIPTION
When permissions differ from default ones, `self._drive_service.permissions().insert()` sometimes causes `HTTP 500 An internal error has occurred which prevented the sharing of these item(s)` (looks like rate limiting).
Can be fixed by including permissions into the file's body and removing that extra call.