### PR TITLE
Auto convert specific file types to Google document types.

### DIFF
--- a/gdstorage/__init__.py
+++ b/gdstorage/__init__.py
@@ -10,3 +10,4 @@ class GoogleDriveStorageConf(AppConf):
         required = ['JSON_KEY_FILE']
 
     USER_EMAIL = None
+    AUTO_CONVERT_MIMETYPES = []

--- a/gdstorage/storage.py
+++ b/gdstorage/storage.py
@@ -325,7 +325,9 @@ class GoogleDriveStorage(Storage):
             body['parents'] = [{'id': parent_id}]
         file_data = self._drive_service.files().insert(
             body=body,
-            media_body=media_body).execute()
+            media_body=media_body,
+            convert=True if mime_type[0] in settings.GOOGLE_DRIVE_STORAGE_AUTO_CONVERT_MIMETYPES else False,
+        ).execute()
 
         # Setting up permissions
         for p in self._permissions:


### PR DESCRIPTION
I want to convert documents in .docx or .odt to Google Docs automatically using `convert` parameter by adding .docx and .odt mimetypes to `GOOGLE_DRIVE_STORAGE_AUTO_CONVERT_MIMETYPES` in settings.py.

```python
GOOGLE_DRIVE_STORAGE_AUTO_CONVERT_MIMETYPES = [
    'application/vnd.oasis.opendocument.text',
    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
]
```

The default value of `GOOGLE_DRIVE_STORAGE_AUTO_CONVERT_MIMETYPES` is `[]` which will not convert anything, so the behavior of the existing code that already use this package will be the same.