### PR TITLE
Error in upload_to='/maps', storage=gd_storage)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -118,7 +118,7 @@ This code block will assign read only capabilities only to the user identified b
    class Map(models.Model):
        id = models.AutoField( primary_key=True)
        map_name = models.CharField(max_length=200)
-       map_data = models.FileField(upload_to='/maps', storage=gd_storage)
+       map_data = models.FileField(upload_to='maps/', storage=gd_storage)
 
 .. note::
 


### PR DESCRIPTION
when migrating this model sale the following message:
'(fields.E202) FileField's 'upload_to' argument must be a relative path, not an absolute path.
	HINT: Remove the leading slash.'
because the route ('maps/') where it is stored is absolute, to solve this error you just have to change it in the following way
change '/maps' from 'maps/'