### PR TITLE
Fix: File uploads fail when file name lacks any path

### DIFF
--- a/gdstorage/storage.py
+++ b/gdstorage/storage.py
@@ -253,40 +253,45 @@ class GoogleDriveStorage(Storage):
         :type parent_id: string
         :returns: dict containing file / folder data if exists or None if does not exists
         """
-        split_filename = self._split_path(filename)
-        if len(split_filename) > 1:
-            # This is an absolute path with folder inside
-            # First check if the first element exists as a folder
-            # If so call the method recursively with next portion of path
-            # Otherwise the path does not exists hence the file does not exists
-            q = "mimeType = '{0}' and name = '{1}'".format(self._GOOGLE_DRIVE_FOLDER_MIMETYPE_,
-                                                            split_filename[0])
-            if parent_id is not None:
-                q = "{0} and '{1}' in parents".format(q, parent_id)
-            results = self._drive_service.files().list(q=q, fields="nextPageToken, files(*)").execute()
-            items = results.get('files', [])
-            for item in items:
-                if item["name"] == split_filename[0]:
-                    # Assuming every folder has a single parent
-                    return self._check_file_exists(os.path.sep.join(split_filename[1:]), item["id"])
-            return None
+        if len(filename) == 0:
+            # This is the lack of directory at the beginning of a 'file.txt'
+            # Since the target file lacks directories, the assumption is that it belongs at '/'
+            return self._drive_service.files().get(fileId='root').execute()
         else:
-            # This is a file, checking if exists
-            q = "name = '{0}'".format(split_filename[0])
-            if parent_id is not None:
-                q = "{0} and '{1}' in parents".format(q, parent_id)
-            results = self._drive_service.files().list(q=q, fields="nextPageToken, files(*)").execute()
-            items = results.get('files', [])
-            if len(items) == 0:
-                q = "" if parent_id is None else "'{0}' in parents".format(parent_id)
+            split_filename = self._split_path(filename)
+            if len(split_filename) > 1:
+                # This is an absolute path with folder inside
+                # First check if the first element exists as a folder
+                # If so call the method recursively with next portion of path
+                # Otherwise the path does not exists hence the file does not exists
+                q = "mimeType = '{0}' and name = '{1}'".format(self._GOOGLE_DRIVE_FOLDER_MIMETYPE_,
+                                                                split_filename[0])
+                if parent_id is not None:
+                    q = "{0} and '{1}' in parents".format(q, parent_id)
                 results = self._drive_service.files().list(q=q, fields="nextPageToken, files(*)").execute()
                 items = results.get('files', [])
                 for item in items:
-                    if split_filename[0] in item["name"]:
-                        return item
+                    if item["name"] == split_filename[0]:
+                        # Assuming every folder has a single parent
+                        return self._check_file_exists(os.path.sep.join(split_filename[1:]), item["id"])
                 return None
             else:
-                return items[0]
+                # This is a file, checking if exists
+                q = "name = '{0}'".format(split_filename[0])
+                if parent_id is not None:
+                    q = "{0} and '{1}' in parents".format(q, parent_id)
+                results = self._drive_service.files().list(q=q, fields="nextPageToken, files(*)").execute()
+                items = results.get('files', [])
+                if len(items) == 0:
+                    q = "" if parent_id is None else "'{0}' in parents".format(parent_id)
+                    results = self._drive_service.files().list(q=q, fields="nextPageToken, files(*)").execute()
+                    items = results.get('files', [])
+                    for item in items:
+                        if split_filename[0] in item["name"]:
+                            return item
+                    return None
+                else:
+                    return items[0]
 
     # Methods that had to be implemented
     # to create a valid storage for Django


### PR DESCRIPTION
When omitting the `upload_to` param in fields like `ImageField`, the file would try to upload with only a `file.txt` file name, since it has no directory structure at all, the upload fails because the file-finding method can’t deal with a `''` directory. This simply handles that edge case by causing the upload to go directly to `/`