### PR TITLE
Support receiving key file contents with an environment variable

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,9 @@ Once installed, there are a few steps to configure the storage:
 
 The `GOOGLE_DRIVE_STORAGE_JSON_KEY_FILE` must be the path to *private json key file* obtained by Google.
 
+Alternatively, you can place the contents of your json private key file into an environment variable named
+`GOOGLE_DRIVE_STORAGE_JSON_KEY_FILE_CONTENTS`, this requires setting `GOOGLE_DRIVE_STORAGE_JSON_KEY_FILE` to `None`.
+
 .. note::
 
    **Django Google Drive Storage** is using `Django Appconf <http://django-appconf.readthedocs.org/>`_ to handle

--- a/gdstorage/storage.py
+++ b/gdstorage/storage.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
 
 import mimetypes
-import os.path
+import os
 from io import BytesIO
 
 import django
 import enum
+import json
 import six
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseUpload
@@ -174,8 +175,17 @@ class GoogleDriveStorage(Storage):
         """
         self._json_keyfile_path = json_keyfile_path or settings.GOOGLE_DRIVE_STORAGE_JSON_KEY_FILE
 
-        credentials = ServiceAccountCredentials.from_json_keyfile_name(self._json_keyfile_path,
-                                                                       scopes=["https://www.googleapis.com/auth/drive"])
+        if self._json_keyfile_path:
+            credentials = ServiceAccountCredentials.from_json_keyfile_name(
+                self._json_keyfile_path,
+                scopes=["https://www.googleapis.com/auth/drive"],
+            )
+        else:
+            credentials = ServiceAccountCredentials.from_json_keyfile_dict(
+                json.loads(os.environ['GOOGLE_DRIVE_STORAGE_JSON_KEY_FILE_CONTENTS']),
+                scopes=["https://www.googleapis.com/auth/drive"],
+            )
+
 
         self._permissions = None
         if permissions is None:


### PR DESCRIPTION
This addresses issue #38 

We’re enabling a env var called `GOOGLE_DRIVE_STORAGE_JSON_KEY_FILE_CONTENTS` now, but only if the setting itself is set as `None` (or other falsey value, TBH)

I believe making it necessary to be explicitly set as `None` will avoid confusion in the future (otherwise, if somebody hasn’t set the setting nor the environment variable, the thing fails when trying to instantiate the service & the message then is way more cryptic for newcomers)

Updated documentation accordingly