### PR TITLE
Bugfix: fileSize key throws a KeyError

### DIFF
--- a/gdstorage/storage.py
+++ b/gdstorage/storage.py
@@ -394,7 +394,7 @@ class GoogleDriveStorage(Storage):
         if file_data is None:
             return 0
         else:
-            return file_data["fileSize"]
+            return file_data["size"]
 
     def url(self, name):
         """


### PR DESCRIPTION
Just fixing a key, from `fileSize` to `size` :)

So, I was getting a key error when Django was trying to call the `size` method after attaching a file into a SummerNote field (Using this module: https://github.com/summernote/django-summernote) this is a generalized error though since there’s no reason the size should change between `fileSize` & `size`. The reason it comes up in this case is that SummerNote tries to output image metadata for internally displaying the image in its WYSIWYG editor.

Here’s a full log of of the error I’ve encountered, for context.

NOTE: The fifth line is just an output of `file_data` I added for debugging purposes, here we can see a `size` but not a `fileSize` -- sorry for the heavy redacting, it’s mostly just me obfuscating names & identifiers, the last one is the error itself.
```
6:51:42 PM web.1 |  [2020-05-16 18:51:42 -0500] [34688] [INFO] Starting gunicorn 20.0.4
6:51:42 PM web.1 |  [2020-05-16 18:51:42 -0500] [34688] [INFO] Listening at: http://0.0.0.0:5000 (34688)
6:51:42 PM web.1 |  [2020-05-16 18:51:42 -0500] [34688] [INFO] Using worker: sync
6:51:42 PM web.1 |  [2020-05-16 18:51:42 -0500] [34691] [INFO] Booting worker with pid: 34691

6:51:51 PM web.1 |  {'kind': 'drive#file', 'id': 'REDACTED', 'name': 'REDACTED', 'mimeType': 'image/jpeg', 'starred': False, 'trashed': False, 'explicitlyTrashed': False, 'parents': ['REDACTED'], 'spaces': ['drive'], 'version': '2', 'webContentLink': 'REDACTED', 'webViewLink': 'REDACTED', 'iconLink': 'REDACTED', 'hasThumbnail': True, 'thumbnailLink': 'REDACTED', 'thumbnailVersion': '1', 'viewedByMe': False, 'createdTime': '2020-05-16T23:51:56.184Z', 'modifiedTime': '2020-05-16T23:51:56.798Z', 'modifiedByMeTime': '2020-05-16T23:51:56.798Z', 'modifiedByMe': True, 'owners': [{'kind': 'drive#user', 'displayName': 'django-storage@{PROJECT-NAME}-dev.iam.gserviceaccount.com', 'me': True, 'permissionId': 'REDACTED', 'emailAddress': 'django-storage@{PROJECT-NAME}-dev.iam.gserviceaccount.com'}], 'lastModifyingUser': {'kind': 'drive#user', 'displayName': 'django-storage@{PROJECT-NAME}-dev.iam.gserviceaccount.com', 'me': True, 'permissionId': 'REDACTED', 'emailAddress': 'django-storage@{PROJECT-NAME}-dev.iam.gserviceaccount.com'}, 'shared': True, 'ownedByMe': True, 'capabilities': {'canAddChildren': False, 'canAddMyDriveParent': False, 'canChangeCopyRequiresWriterPermission': True, 'canChangeViewersCanCopyContent': True, 'canComment': True, 'canCopy': True, 'canDelete': True, 'canDownload': True, 'canEdit': True, 'canListChildren': False, 'canModifyContent': True, 'canMoveChildrenWithinDrive': False, 'canMoveItemIntoTeamDrive': True, 'canMoveItemOutOfDrive': True, 'canMoveItemWithinDrive': True, 'canReadRevisions': True, 'canRemoveChildren': False, 'canRemoveMyDriveParent': True, 'canRename': True, 'canShare': True, 'canTrash': True, 'canUntrash': True}, 'viewersCanCopyContent': True, 'copyRequiresWriterPermission': False, 'writersCanShare': True, 'permissions': [{'kind': 'drive#permission', 'id': 'anyoneWithLink', 'type': 'anyone', 'role': 'reader', 'allowFileDiscovery': False}, {'kind': 'drive#permission', 'id': 'REDACTED', 'type': 'user', 'emailAddress': 'django-storage@{PROJECT-NAME}-dev.iam.gserviceaccount.com', 'role': 'owner', 'displayName': 'django-storage@{PROJECT-NAME}-dev.iam.gserviceaccount.com', 'deleted': False}], 'permissionIds': ['anyoneWithLink', 'REDACTED'], 'originalFilename': 'REDACTED', 'fullFileExtension': 'jpg', 'fileExtension': 'jpg', 'md5Checksum': 'REDACTED', 'size': '25918', 'quotaBytesUsed': '25918', 'headRevisionId': 'REDACTED', 'imageMediaMetadata': {'width': 400, 'height': 400, 'rotation': 0}, 'isAppAuthorized': True}

6:51:51 PM web.1 |  Internal Server Error: /summernote/upload_attachment/
6:51:51 PM web.1 |  Traceback (most recent call last):
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/base.py", line 828, in _resolve_lookup
6:51:51 PM web.1 |      current = current[bit]
6:51:51 PM web.1 |  TypeError: 'FieldFile' object is not subscriptable
6:51:51 PM web.1 |  During handling of the above exception, another exception occurred:
6:51:51 PM web.1 |  Traceback (most recent call last):
6:51:51 PM web.1 |    File "/ Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
6:51:51 PM web.1 |      response = get_response(request)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/core/handlers/base.py", line 115, in _get_response
6:51:51 PM web.1 |      response = self.process_exception_by_middleware(e, request)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/core/handlers/base.py", line 113, in _get_response
6:51:51 PM web.1 |      response = wrapped_callback(request, *callback_args, **callback_kwargs)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/views/generic/base.py", line 71, in view
6:51:51 PM web.1 |      return self.dispatch(request, *args, **kwargs)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/contrib/auth/mixins.py", line 109, in dispatch
6:51:51 PM web.1 |      return super().dispatch(request, *args, **kwargs)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/views/generic/base.py", line 97, in dispatch
6:51:51 PM web.1 |      return handler(request, *args, **kwargs)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django_summernote/utils.py", line 133, in inner_dec
6:51:51 PM web.1 |      res = func(*args, **kwargs)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django_summernote/views.py", line 158, in post
6:51:51 PM web.1 |      'attachments': attachments,
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/loader.py", line 62, in render_to_string
6:51:51 PM web.1 |      return template.render(context, request)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/backends/django.py", line 61, in render
6:51:51 PM web.1 |      return self.template.render(context)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/base.py", line 171, in render
6:51:51 PM web.1 |      return self._render(context)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/base.py", line 163, in _render
6:51:51 PM web.1 |      return self.nodelist.render(context)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/base.py", line 936, in render
6:51:51 PM web.1 |      bit = node.render_annotated(context)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/base.py", line 903, in render_annotated
6:51:51 PM web.1 |      return self.render(context)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/defaulttags.py", line 209, in render
6:51:51 PM web.1 |      nodelist.append(node.render_annotated(context))
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/base.py", line 903, in render_annotated
6:51:51 PM web.1 |      return self.render(context)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/base.py", line 986, in render
6:51:51 PM web.1 |      output = self.filter_expression.resolve(context)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/base.py", line 670, in resolve
6:51:51 PM web.1 |      obj = self.var.resolve(context)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/base.py", line 795, in resolve
6:51:51 PM web.1 |      value = self._resolve_lookup(context)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/template/base.py", line 836, in _resolve_lookup
6:51:51 PM web.1 |      current = getattr(current, bit)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/django/db/models/fields/files.py", line 69, in size
6:51:51 PM web.1 |      return self.storage.size(self.name)
6:51:51 PM web.1 |    File "/Users/USERNAME/.virtualenvs/{PROJECT-NAME}/lib/python3.7/site-packages/gdstorage/storage.py", line 402, in size
6:51:51 PM web.1 |      return file_data["fileSize"]
6:51:51 PM web.1 |  KeyError: 'fileSize'
```